### PR TITLE
style(npm install): :loud_sound: Add loglevel to track npm install process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Copy environment variables file and fill it with API keys and secrets.
 cp .env.example .env
 ```
 
-Start the project (add a `-d` flag to run it in background) (It may takes a few minutes on first install because `node_modules` are installed in the background)
+Start the project (add a `-d` flag to run it in background)
 ```sh
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 ```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,9 +14,9 @@ services:
     ports:
       - "5555:5555"
     # We use db push for now because we don't have any migrations yet, prototyping the database
-    command: sh -c "npm install && npx prisma db push && (npx prisma studio &) && npm run start:dev"
+    command: sh -c "npm install --loglevel info && npx prisma db push && (npx prisma studio &) && npm run start:dev"
     # The following command is used to run migrations instead of db push
-    # command: sh -c "npm install && npx prisma migrate dev && (npx prisma studio &) && npm run start:dev"
+    # command: sh -c "npm install --loglevel info && npx prisma migrate dev && (npx prisma studio &) && npm run start:dev"
 
   database:
     environment:


### PR DESCRIPTION
Salut les gars,
J'ai finalement compris pourquoi on ne voyait pas npm faire l'install en background.

## Explication
C'est parce que quand npm installe les modules, il update la même ligne de log en permanence (il ne génère pas 100 lignes si on a 100 extensions à installer)
Cette fonctionnalité d'update d'une ligne dans le terminal n'est pas possible lorsque l'on affiche les logs à la volée d'une ou plusieurs applications en même temps dans le même terminal.
Et c'est justement notre cas, lors du Docker compose, docker regroupe les logs des containers NodeJS, et les deux containers PostgreSQL.

## Fix
J'ai ajouté un mode verbeux à la commande `npm install` qui affiche le nom des extensions au fur et à mesure de leur installation.