### PR TITLE
Refactored PrismaService

### DIFF
--- a/src/assos/assos.service.ts
+++ b/src/assos/assos.service.ts
@@ -44,7 +44,7 @@ export class AssosService {
           }
         : {}),
     };
-    const assos = await this.prisma.asso.findMany({
+    const assos = await this.prisma.normalize.asso.findMany({
       where,
       take: this.config.PAGINATION_PAGE_SIZE,
       skip: ((query.page ?? 1) - 1) * this.config.PAGINATION_PAGE_SIZE,
@@ -65,7 +65,7 @@ export class AssosService {
    * @returns the {@link assoFormatted} of the asso matching the given id
    */
   async getAsso(assoId: string): Promise<Asso> {
-    return this.prisma.asso.findUnique({
+    return this.prisma.normalize.asso.findUnique({
       where: {
         id: assoId,
       },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -63,7 +63,7 @@ export class AuthService {
     }
     try {
       const isUTTMail = dto.mail?.endsWith('@utt.fr');
-      const user = await this.prisma.withDefaultBehaviour.user.create({
+      const user = await this.prisma.user.create({
         data: {
           login: dto.login,
           hash: dto.password ? await this.getHash(dto.password) : undefined,
@@ -190,7 +190,7 @@ export class AuthService {
    */
   async signin(dto: AuthSignInReqDto): Promise<string | null> {
     // find the user by login, if it does not exist, throw exception
-    const user = await this.prisma.withDefaultBehaviour.user.findUnique({
+    const user = await this.prisma.user.findUnique({
       where: {
         login: dto.login,
       },

--- a/src/auth/strategy/jwt.strategy.ts
+++ b/src/auth/strategy/jwt.strategy.ts
@@ -15,7 +15,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   async validate(payload: { sub: string; login: string }): Promise<User> {
-    return await this.prisma.user.findUnique({
+    return await this.prisma.normalize.user.findUnique({
       where: {
         id: payload.sub,
       },

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -22,16 +22,6 @@ export class PrismaService extends PrismaClient<ReturnType<typeof prismaOptions>
   }
 }
 
-function createPrismaClient(config: ConfigModule) {
-  return new PrismaClient({
-    datasources: {
-      db: {
-        url: config.DATABASE_URL,
-      },
-    },
-  });
-}
-
 const prismaOptions = (config: ConfigModule) => ({
   datasources: {
     db: {
@@ -78,7 +68,7 @@ export type UserFriendlyRequestType<
 > = Omit<RequestType<ModelName, FunctionName>, 'select' | 'include' | 'orderBy'> &
   (Record<string, never> extends CustomArgs ? { args?: never } : { args: CustomArgs });
 export type Formatter<RawEntity, FormattedEntity, QueryArgs extends object> = (
-  prisma: ReturnType<typeof createPrismaClient>,
+  prisma: PrismaClient,
   raw: RawEntity,
   args: QueryArgs,
 ) => MayBePromise<FormattedEntity>;

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -12,34 +12,13 @@ import { generateCustomUeCommentReplyModel } from '../ue/comments/interfaces/com
 import { generateCustomAssoModel } from '../assos/interfaces/asso.interface';
 import { generateCustomCreditCategoryModel } from '../ue/credit/interfaces/credit-category.interface';
 
-// This interface is used to tell typescript that, even tho it does not understand it, PrismaService IS actually a ReturnType<typeof createPrismaClientExtension>
-// TS cannot infer it alone as the construction of the class is made using reflection.
-// We can't use a type there, or else typescript will complain about the fact that PrismaService is defined twice.
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface PrismaService extends ReturnType<typeof createPrismaClientExtension> {}
-
 @Injectable()
-export class PrismaService implements ReturnType<typeof createPrismaClientExtension> {
-  readonly withDefaultBehaviour: PrismaClient;
+export class PrismaService extends PrismaClient<ReturnType<typeof prismaOptions>> {
+  readonly normalize: ReturnType<typeof createNormalizedEntitiesUtility>;
+
   constructor(config: ConfigModule) {
-    this.withDefaultBehaviour = createPrismaClient(config);
-    const prisma = createPrismaClientExtension(this.withDefaultBehaviour);
-    return new Proxy(this, {
-      // So, basically, every time a property will be accessed, this function will be called :
-      // - target is equivalent to this
-      // - prop is the name of the property
-      // - receiver is something else, we don't need it here and I don't want to search the internet
-      // What we do here is :
-      // - try to return the property as normal. For example, if we do prismaService.withDefaultBehaviour, this will act as normal
-      // - if we can't find a value for it, return the same value but for the prisma client.
-      // That way, we are simulating an inheritance, but without actually doing one : the class that needs to be extended is generated in the constructor
-      get(target, prop, receiver) {
-        if (prop in target) {
-          return Reflect.get(target, prop, receiver);
-        }
-        return Reflect.get(prisma, prop, receiver);
-      },
-    });
+    super(prismaOptions(config));
+    this.normalize = createNormalizedEntitiesUtility(this);
   }
 }
 
@@ -53,20 +32,33 @@ function createPrismaClient(config: ConfigModule) {
   });
 }
 
-function createPrismaClientExtension(prisma: ReturnType<typeof createPrismaClient>) {
-  return prisma.$extends({
-    model: {
-      user: generateCustomUserModel(prisma),
-      ueComment: generateCustomCommentModel(prisma),
-      ueStarCriterion: generateCustomCriterionModel(prisma),
-      ueCommentReply: generateCustomUeCommentReplyModel(prisma),
-      ueStarVote: generateCustomRateModel(prisma),
-      ue: generateCustomUeModel(prisma),
-      ueAnnal: generateCustomUeAnnalModel(prisma),
-      asso: generateCustomAssoModel(prisma),
-      ueCreditCategory: generateCustomCreditCategoryModel(prisma),
+const prismaOptions = (config: ConfigModule) => ({
+  datasources: {
+    db: {
+      url: config.DATABASE_URL,
     },
-  });
+  },
+});
+
+/**
+ * @typedef {import('@prisma/client').Prisma.UserDelegate} UserDelegate
+ */
+
+function createNormalizedEntitiesUtility(prisma: PrismaClient) {
+  return {
+    /**
+     * @type {UserDelegate['findMany']}
+     */
+    user: generateCustomUserModel(prisma),
+    ueComment: generateCustomCommentModel(prisma),
+    ueStarCriterion: generateCustomCriterionModel(prisma),
+    ueCommentReply: generateCustomUeCommentReplyModel(prisma),
+    ueStarVote: generateCustomRateModel(prisma),
+    ue: generateCustomUeModel(prisma),
+    ueAnnal: generateCustomUeAnnalModel(prisma),
+    asso: generateCustomAssoModel(prisma),
+    ueCreditCategory: generateCustomCreditCategoryModel(prisma),
+  };
 }
 
 // UTILITIES TO GENERATE CUSTOM MODEL FUNCTIONS
@@ -85,10 +77,10 @@ export type UserFriendlyRequestType<
   CustomArgs extends object,
 > = Omit<RequestType<ModelName, FunctionName>, 'select' | 'include' | 'orderBy'> &
   (Record<string, never> extends CustomArgs ? { args?: never } : { args: CustomArgs });
-export type Formatter<RawEntity, FormattedEntity, FormatterArgs extends any[]> = (
+export type Formatter<RawEntity, FormattedEntity, QueryArgs extends object> = (
   prisma: ReturnType<typeof createPrismaClient>,
   raw: RawEntity,
-  ...args: FormatterArgs
+  args: QueryArgs,
 ) => MayBePromise<FormattedEntity>;
 
 function generateCustomModelFunction<
@@ -96,20 +88,19 @@ function generateCustomModelFunction<
   FunctionName extends FunctionNameType<ModelName>,
   Raw,
   Formatted extends Awaited<any>,
-  FormatterArgs extends any[],
   QueryArgs extends object,
 >(
   prisma: PrismaClient,
   modelName: ModelName,
   functionName: FunctionName,
   selectFilter: Partial<RequestType<ModelName, FunctionName>>,
-  format: Formatter<Raw, Formatted, FormatterArgs>,
+  format: Formatter<Raw, Formatted, QueryArgs>,
   queryUpdater: (
     query: RequestType<ModelName, FunctionName>,
     args: QueryArgs,
   ) => MayBePromise<RequestType<ModelName, FunctionName>>,
-): (params: UserFriendlyRequestType<ModelName, FunctionName, QueryArgs>, ...args: FormatterArgs) => Promise<Formatted> {
-  return async (args, ...formatterArgs) => {
+): (params: UserFriendlyRequestType<ModelName, FunctionName, QueryArgs>) => Promise<Formatted> {
+  return async (args) => {
     const res = await (prisma[modelName][functionName] as (arg: RequestType<ModelName, FunctionName>) => Raw)(
       await queryUpdater(
         {
@@ -119,7 +110,7 @@ function generateCustomModelFunction<
         args.args,
       ),
     );
-    return res ? format(prisma, res, ...formatterArgs) : (res as null);
+    return res ? format(prisma, res, args.args) : (res as null);
   };
 }
 
@@ -130,13 +121,12 @@ export function generateCustomModel<
   ModelName extends ModelNameType,
   Raw,
   Formatted,
-  FormatterArgs extends any[],
-  QueryArgs extends object,
+  QueryArgs extends Record<string, any>,
 >(
   prisma: PrismaClient,
   modelName: ModelName,
   selectFilter: Partial<RequestType<ModelName, FunctionNameType<ModelName>>>,
-  format: Formatter<Raw, Formatted, FormatterArgs>,
+  format: Formatter<Raw, Formatted, QueryArgs>,
   queryUpdater: (
     query: RequestType<ModelName, FunctionNameType<ModelName>>,
     args: QueryArgs,
@@ -145,12 +135,10 @@ export function generateCustomModel<
   const customModel: {
     [K in (typeof singleValueMethods)[number]]?: (
       arg: UserFriendlyRequestType<ModelName, FunctionNameType<ModelName> & K, QueryArgs>,
-      ...formatterArgs: FormatterArgs
     ) => Promise<Formatted>;
   } & {
     [K in (typeof multiValueMethods)[number]]?: (
       arg: UserFriendlyRequestType<ModelName, FunctionNameType<ModelName> & K, QueryArgs>,
-      ...formatterArgs: FormatterArgs
     ) => Promise<Formatted[]>;
   } = {};
   for (const functionName of singleValueMethods) {
@@ -171,8 +159,7 @@ export function generateCustomModel<
       modelName,
       functionName as FunctionNameType<ModelName>,
       selectFilter,
-      (prisma, values: Raw[], ...args: FormatterArgs) =>
-        Promise.all(values.map((value) => format(prisma, value, ...args))),
+      (prisma, values: Raw[], args: QueryArgs) => Promise.all(values.map((value) => format(prisma, value, args))),
       queryUpdater,
     );
   }

--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -17,7 +17,7 @@ export class ProfileService {
 
   async setHomepageWidgets(userId: string, widgets: HomepageWidgetsUpdateElement[]): Promise<RawHomepageWidget[]> {
     return (
-      await this.prisma.withDefaultBehaviour.user.update({
+      await this.prisma.user.update({
         where: { id: userId },
         data: { homepageWidgets: { deleteMany: {}, createMany: { data: widgets } } },
         select: { homepageWidgets: true },

--- a/src/ue/annals/annals.controller.ts
+++ b/src/ue/annals/annals.controller.ts
@@ -181,7 +181,7 @@ export class AnnalsController {
   @ApiOkResponse({ type: UeAnnalResDto })
   @ApiAppErrorResponse(ERROR_CODE.NO_SUCH_ANNAL)
   @ApiAppErrorResponse(ERROR_CODE.NOT_ANNAL_SENDER)
-  async deleteUeAnnal(@UUIDParam('annalId') annalId: string, @GetUser() user: User) {
+  async deleteUeAnnal(@UUIDParam('annalId') annalId: string, @GetUser() user: User): Promise<UeAnnalResDto> {
     if (!(await this.annalsService.isAnnalAccessible(user.id, annalId, user.permissions.includes('annalModerator'))))
       throw new AppException(ERROR_CODE.NO_SUCH_ANNAL, annalId);
     if (!(await this.annalsService.isUeAnnalSender(user.id, annalId)) && !user.permissions.includes('annalModerator'))

--- a/src/ue/annals/annals.service.ts
+++ b/src/ue/annals/annals.service.ts
@@ -67,7 +67,7 @@ export class AnnalsService {
       },
     });
     // Create upload/file entry
-    return this.prisma.ueAnnal.create({
+    return this.prisma.normalize.ueAnnal.create({
       data: {
         type: {
           connect: {
@@ -106,7 +106,7 @@ export class AnnalsService {
         },
       },
     };
-    const fileEntry = await this.prisma.ueAnnal.findUnique(dbFilter);
+    const fileEntry = await this.prisma.normalize.ueAnnal.findUnique(dbFilter);
     // We won't wait for the file to be processed to send the response.
     // Files do not need to be processed instantly and will only be displayed to all users when processed
     const promise = (async () => {
@@ -180,7 +180,7 @@ export class AnnalsService {
 
   async getUeAnnalsList(user: User, ueCode: string, includeAll: boolean) {
     return (
-      await this.prisma.ueAnnal.findMany({
+      await this.prisma.normalize.ueAnnal.findMany({
         where: {
           ueof: {
             ue: {
@@ -254,7 +254,7 @@ export class AnnalsService {
   }
 
   async getUeAnnal(annalId: string, userId: string, includeAll: boolean) {
-    return this.prisma.ueAnnal.findUnique({
+    return this.prisma.normalize.ueAnnal.findUnique({
       where: {
         id: annalId,
         deletedAt: includeAll ? undefined : null,
@@ -285,7 +285,7 @@ export class AnnalsService {
   }
 
   async getUeAnnalFile(annalId: string, userId: string, includeAll: boolean) {
-    const metadata = await this.prisma.ueAnnal.findUnique({
+    const metadata = await this.prisma.normalize.ueAnnal.findUnique({
       where: {
         id: annalId,
         deletedAt: includeAll ? undefined : null,
@@ -332,7 +332,7 @@ export class AnnalsService {
   }
 
   async updateAnnalMetadata(annalId: string, metadata: UpdateAnnalReqDto) {
-    return this.prisma.ueAnnal.update({
+    return this.prisma.normalize.ueAnnal.update({
       where: {
         id: annalId,
       },
@@ -352,7 +352,7 @@ export class AnnalsService {
   }
 
   async deleteAnnal(annalId: string) {
-    return this.prisma.ueAnnal.update({
+    return this.prisma.normalize.ueAnnal.update({
       where: {
         id: annalId,
       },

--- a/src/ue/comments/comments.service.ts
+++ b/src/ue/comments/comments.service.ts
@@ -27,25 +27,22 @@ export class CommentsService {
   ): Promise<Pagination<UeComment>> {
     // Use a prisma transaction to execute two requests at once:
     // We fetch a page of comments matching our filters and retrieve the total count of comments matching our filters
-    const comments = await this.prisma.ueComment.findMany(
-      {
-        args: {
-          userId: userId,
-          includeLastValidatedBody: bypassAnonymousData,
-          includeDeletedReplied: bypassAnonymousData,
-        },
-        where: {
-          ueof: {
-            ue: {
-              code: dto.ueCode,
-            },
+    const comments = await this.prisma.normalize.ueComment.findMany({
+      args: {
+        userId: userId,
+        includeLastValidatedBody: bypassAnonymousData,
+        includeDeletedReplied: bypassAnonymousData,
+      },
+      where: {
+        ueof: {
+          ue: {
+            code: dto.ueCode,
           },
         },
-        take: this.config.PAGINATION_PAGE_SIZE,
-        skip: ((dto.page ?? 1) - 1) * this.config.PAGINATION_PAGE_SIZE,
       },
-      userId,
-    );
+      take: this.config.PAGINATION_PAGE_SIZE,
+      skip: ((dto.page ?? 1) - 1) * this.config.PAGINATION_PAGE_SIZE,
+    });
     const commentCount = await this.prisma.ueComment.count({
       where: { ueof: { ue: { code: dto.ueCode } } },
     });
@@ -68,19 +65,16 @@ export class CommentsService {
    * @returns a page of {@link UeComment} matching the user query
    */
   async getCommentFromId(commentId: string, userId: string, isModerator: boolean): Promise<UeComment> {
-    const comment = await this.prisma.ueComment.findUnique(
-      {
-        args: {
-          includeDeletedReplied: isModerator,
-          includeLastValidatedBody: isModerator,
-          userId,
-        },
-        where: {
-          id: commentId,
-        },
+    const comment = await this.prisma.normalize.ueComment.findUnique({
+      args: {
+        includeDeletedReplied: isModerator,
+        includeLastValidatedBody: isModerator,
+        userId,
       },
-      userId,
-    );
+      where: {
+        id: commentId,
+      },
+    });
     return comment;
   }
 
@@ -92,7 +86,7 @@ export class CommentsService {
    * @returns whether the user is the author of the {@link commentId | comment}
    */
   async isUserCommentAuthor(userId: string, commentId: string): Promise<boolean> {
-    const comment = await this.prisma.withDefaultBehaviour.ueComment.findUnique({
+    const comment = await this.prisma.ueComment.findUnique({
       where: { id: commentId },
       select: { authorId: true },
     });
@@ -164,13 +158,13 @@ export class CommentsService {
    */
   async hasAlreadyPostedAComment(userId: string, ueCode: string) {
     // Find the UE
-    const ue = await this.prisma.withDefaultBehaviour.ue.findUnique({
+    const ue = await this.prisma.ue.findUnique({
       where: {
         code: ueCode,
       },
     });
     // Find a comment (in the UE) whose author is the user
-    const comment = await this.prisma.ueComment.findMany({
+    const comment = await this.prisma.normalize.ueComment.findMany({
       args: {
         includeDeletedReplied: false,
         includeLastValidatedBody: false,
@@ -196,36 +190,33 @@ export class CommentsService {
   async createComment(body: UeCommentPostReqDto, userId: string): Promise<UeComment> {
     // Use last semester done when creating the comment
     const lastSemester = await this.getLastUserSubscription(userId, body.ueCode);
-    return this.prisma.ueComment.create(
-      {
-        args: {
-          includeDeletedReplied: true,
-          includeLastValidatedBody: true,
-          userId,
+    return this.prisma.normalize.ueComment.create({
+      args: {
+        includeDeletedReplied: true,
+        includeLastValidatedBody: true,
+        userId,
+      },
+      data: {
+        body: body.body,
+        isAnonymous: body.isAnonymous ?? false,
+        updatedAt: new Date(),
+        author: {
+          connect: {
+            id: userId,
+          },
         },
-        data: {
-          body: body.body,
-          isAnonymous: body.isAnonymous ?? false,
-          updatedAt: new Date(),
-          author: {
-            connect: {
-              id: userId,
-            },
+        ueof: {
+          connect: {
+            code: lastSemester.ueofCode,
           },
-          ueof: {
-            connect: {
-              code: lastSemester.ueofCode,
-            },
-          },
-          semester: {
-            connect: {
-              code: lastSemester.semesterId,
-            },
+        },
+        semester: {
+          connect: {
+            code: lastSemester.semesterId,
           },
         },
       },
-      userId,
-    );
+    });
   }
 
   /**
@@ -242,7 +233,7 @@ export class CommentsService {
     userId: string,
     isModerator: boolean,
   ): Promise<UeComment> {
-    const previousComment = await this.prisma.ueComment.findUnique({
+    const previousComment = await this.prisma.normalize.ueComment.findUnique({
       args: {
         userId,
         includeDeletedReplied: true,
@@ -258,26 +249,23 @@ export class CommentsService {
       previousComment.status & CommentStatus.VALIDATED &&
       !isModerator;
 
-    return this.prisma.ueComment.update(
-      {
-        args: {
-          userId,
-          includeDeletedReplied: true,
-          includeLastValidatedBody: true,
-        },
-        where: {
-          id: commentId,
-        },
-        data: {
-          body: body.body,
-          isAnonymous: body.isAnonymous,
-          validatedAt: needsValidationAgain ? null : undefined,
-          lastValidatedBody: needsValidationAgain ? previousComment.body : undefined,
-          updatedAt: new Date(),
-        },
+    return this.prisma.normalize.ueComment.update({
+      args: {
+        userId,
+        includeDeletedReplied: true,
+        includeLastValidatedBody: true,
       },
-      userId,
-    );
+      where: {
+        id: commentId,
+      },
+      data: {
+        body: body.body,
+        isAnonymous: body.isAnonymous,
+        validatedAt: needsValidationAgain ? null : undefined,
+        lastValidatedBody: needsValidationAgain ? previousComment.body : undefined,
+        updatedAt: new Date(),
+      },
+    });
   }
 
   /**
@@ -306,7 +294,7 @@ export class CommentsService {
    * @returns the created {@link UeCommentReply}
    */
   async replyComment(userId: string, commentId: string, reply: CommentReplyReqDto): Promise<UeCommentReply> {
-    return this.prisma.ueCommentReply.create({
+    return this.prisma.normalize.ueCommentReply.create({
       data: {
         body: reply.body,
         commentId,
@@ -323,7 +311,7 @@ export class CommentsService {
    * @returns the updated {@link UeCommentReply}
    */
   async editReply(replyId: string, reply: CommentReplyReqDto): Promise<UeCommentReply> {
-    return this.prisma.ueCommentReply.update({
+    return this.prisma.normalize.ueCommentReply.update({
       data: {
         body: reply.body,
       },
@@ -340,7 +328,7 @@ export class CommentsService {
    * @returns the deleted {@link UeCommentReply}
    */
   async deleteReply(replyId: string): Promise<UeCommentReply> {
-    return this.prisma.ueCommentReply.update({
+    return this.prisma.normalize.ueCommentReply.update({
       where: {
         id: replyId,
       },
@@ -388,22 +376,19 @@ export class CommentsService {
    * @returns the deleted {@link UeComment}
    */
   deleteComment(commentId: string, userId: string): Promise<UeComment> {
-    return this.prisma.ueComment.update(
-      {
-        args: {
-          userId,
-          includeDeletedReplied: true,
-          includeLastValidatedBody: false,
-        },
-        where: {
-          id: commentId,
-        },
-        data: {
-          deletedAt: new Date(),
-        },
+    return this.prisma.normalize.ueComment.update({
+      args: {
+        userId,
+        includeDeletedReplied: true,
+        includeLastValidatedBody: false,
       },
-      userId,
-    );
+      where: {
+        id: commentId,
+      },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
   }
 
   /**

--- a/src/ue/comments/interfaces/comment.interface.ts
+++ b/src/ue/comments/interfaces/comment.interface.ts
@@ -118,13 +118,13 @@ export function generateCustomCommentModel(prisma: PrismaClient) {
   );
 }
 
-export function formatComment(prisma: PrismaClient, comment: UnformattedUEComment, userId?: string): UeComment {
+export function formatComment(prisma: PrismaClient, comment: UnformattedUEComment, args: UEExtraArgs): UeComment {
   return {
     ...omit(comment, 'deletedAt', 'validatedAt'),
     answers: comment.answers.map((answer) => formatReply(prisma, answer)),
     status: (comment.deletedAt && CommentStatus.DELETED) | (comment.validatedAt && CommentStatus.VALIDATED),
     upvotes: comment.upvotes.length,
-    upvoted: comment.upvotes.some((upvote) => upvote.userId == userId),
+    upvoted: comment.upvotes.some((upvote) => upvote.userId == args.userId),
     semester: comment.semester.code,
   };
 }

--- a/src/ue/ue.service.ts
+++ b/src/ue/ue.service.ts
@@ -131,7 +131,7 @@ export class UeService {
       ].filter((query) => query),
       // Filter per credit type
     } satisfies Prisma.UeWhereInput;
-    const items = await this.prisma.ue.findMany({
+    const items = await this.prisma.normalize.ue.findMany({
       where,
       take: this.config.PAGINATION_PAGE_SIZE,
       skip: ((query.page ?? 1) - 1) * this.config.PAGINATION_PAGE_SIZE,
@@ -154,7 +154,7 @@ export class UeService {
   getUe(code: string): Promise<Ue> {
     // Fetch an ue from the database. This ue shall not be returned as is because
     // it is not formatted at that point.
-    return this.prisma.ue.findUnique({
+    return this.prisma.normalize.ue.findUnique({
       where: {
         code,
       },
@@ -258,7 +258,7 @@ export class UeService {
    * @returns the list of all criteria
    */
   async getRateCriteria(): Promise<Criterion[]> {
-    return this.prisma.ueStarCriterion.findMany({});
+    return this.prisma.normalize.ueStarCriterion.findMany({});
   }
 
   /**
@@ -287,7 +287,7 @@ export class UeService {
           async (ueof) =>
             [
               ueof.code,
-              await this.prisma.ueStarVote.findMany({
+              await this.prisma.normalize.ueStarVote.findMany({
                 where: {
                   userId: userId,
                   ueofCode: ueof.code,
@@ -308,7 +308,7 @@ export class UeService {
    * @returns the new rate of the {@link ueofCode | ue} for the {@link user}
    */
   async rateUeof(userId: string, ueofCode: string, dto: UeRateReqDto): Promise<UeRating> {
-    return this.prisma.ueStarVote.upsert({
+    return this.prisma.normalize.ueStarVote.upsert({
       where: {
         ueofCode_userId_criterionId: {
           ueofCode: ueofCode,
@@ -329,7 +329,7 @@ export class UeService {
   }
 
   async unRateUeof(userId: string, ueofCode: string, criterionId: string): Promise<UeRating> {
-    return this.prisma.ueStarVote.delete({
+    return this.prisma.normalize.ueStarVote.delete({
       where: {
         ueofCode_userId_criterionId: {
           ueofCode: ueofCode,
@@ -343,7 +343,7 @@ export class UeService {
   async getUesOfUser(userId: string): Promise<Ue[]> {
     const currentSemester = await this.semesterService.getCurrentSemester();
     if (currentSemester === null) return [];
-    return this.prisma.ue.findMany({
+    return this.prisma.normalize.ue.findMany({
       where: {
         ueofs: {
           some: {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -66,7 +66,7 @@ export default class UsersService {
           }
         : {}),
     } satisfies Prisma.UserWhereInput;
-    const items = await this.prisma.user.findMany({
+    const items = await this.prisma.normalize.user.findMany({
       where,
       take: this.config.PAGINATION_PAGE_SIZE,
       skip: ((dto.page ?? 1) - 1) * this.config.PAGINATION_PAGE_SIZE,
@@ -80,7 +80,7 @@ export default class UsersService {
   }
 
   fetchUser(userId: string): Promise<User> {
-    return this.prisma.user.findUnique({
+    return this.prisma.normalize.user.findUnique({
       where: { id: userId },
     });
   }
@@ -96,7 +96,7 @@ export default class UsersService {
         FROM UserInfos
         WHERE EXTRACT(DAY FROM birthday) = ${date.getUTCDate()}
           AND EXTRACT(MONTH FROM birthday) = ${date.getUTCMonth() + 1}`) as Array<{ id: string }>;
-    return this.prisma.user.findMany({ where: { infosId: { in: userIds.map((u) => u.id) } } });
+    return this.prisma.normalize.user.findMany({ where: { infosId: { in: userIds.map((u) => u.id) } } });
   }
 
   async fetchUserAssoMemberships(userId: string): Promise<UserAssoMembership[]> {
@@ -126,7 +126,7 @@ export default class UsersService {
   }
 
   async updateUserProfil(userId: string, dto: UserUpdateReqDto): Promise<User> {
-    return this.prisma.user.update({
+    return this.prisma.normalize.user.update({
       where: { id: userId },
       data: {
         infos: {

--- a/test/e2e/auth/signup-e2e-spec.ts
+++ b/test/e2e/auth/signup-e2e-spec.ts
@@ -93,7 +93,7 @@ const SignupE2ESpec = e2eSuite('POST /auth/signup', (app) => {
     await pactum.spec().post('/auth/signup').withBody(dto).expectBodyContains('access_token').expectStatus(201);
     const user = await app()
       .get(PrismaService)
-      .user.findUnique({ where: { login: dto.login } });
+      .normalize.user.findUnique({ where: { login: dto.login } });
     expect(user).not.toBeNull();
     expect(user.login).toEqual(dto.login);
     expect(user.firstName).toEqual(dto.firstName);

--- a/test/e2e/ue/comments/delete-comment.e2e-spec.ts
+++ b/test/e2e/ue/comments/delete-comment.e2e-spec.ts
@@ -78,7 +78,7 @@ const DeleteComment = e2eSuite('DELETE /ue/comments/:commentId', (app) => {
       });
     await app()
       .get(PrismaService)
-      .ueComment.delete({
+      .normalize.ueComment.delete({
         args: {
           includeDeletedReplied: false,
           includeLastValidatedBody: false,

--- a/test/e2e/ue/comments/get-comment.e2e-spec.ts
+++ b/test/e2e/ue/comments/get-comment.e2e-spec.ts
@@ -90,16 +90,13 @@ const GetCommentsE2ESpec = e2eSuite('GET /ue/comments', (app) => {
       });
     const extendedComments = await app()
       .get(PrismaService)
-      .ueComment.findMany(
-        {
-          args: {
-            userId: user.id,
-            includeDeletedReplied: false,
-            includeLastValidatedBody: false,
-          },
+      .normalize.ueComment.findMany({
+        args: {
+          userId: user.id,
+          includeDeletedReplied: false,
+          includeLastValidatedBody: false,
         },
-        user.id,
-      );
+      });
     const commentsFiltered = {
       items: extendedComments
         .sort((a, b) =>
@@ -128,16 +125,13 @@ const GetCommentsE2ESpec = e2eSuite('GET /ue/comments', (app) => {
   it('should return the second page of comments', async () => {
     const extendedComments = await app()
       .get(PrismaService)
-      .ueComment.findMany(
-        {
-          args: {
-            userId: user.id,
-            includeDeletedReplied: false,
-            includeLastValidatedBody: false,
-          },
+      .normalize.ueComment.findMany({
+        args: {
+          userId: user.id,
+          includeDeletedReplied: false,
+          includeLastValidatedBody: false,
         },
-        user.id,
-      );
+      });
     return pactum
       .spec()
       .withBearerToken(user.token)
@@ -173,16 +167,13 @@ const GetCommentsE2ESpec = e2eSuite('GET /ue/comments', (app) => {
       });
     const extendedComments = await app()
       .get(PrismaService)
-      .ueComment.findMany(
-        {
-          args: {
-            userId: user.id,
-            includeDeletedReplied: false,
-            includeLastValidatedBody: true,
-          },
+      .normalize.ueComment.findMany({
+        args: {
+          userId: user.id,
+          includeDeletedReplied: false,
+          includeLastValidatedBody: true,
         },
-        user.id,
-      );
+      });
     const commentsFiltered = {
       items: extendedComments
         .sort((a, b) =>

--- a/test/e2e/users/get-current-user-e2e-spec.ts
+++ b/test/e2e/users/get-current-user-e2e-spec.ts
@@ -16,7 +16,7 @@ const GetCurrentUserE2ESpec = e2eSuite('GET /users/current', (app) => {
   it('should successfully find the user', async () => {
     const userFromDb = await app()
       .get(PrismaService)
-      .user.findUnique({
+      .normalize.user.findUnique({
         where: { login: user.login },
       });
     const branch = userFromDb.branchSubscriptions.find(

--- a/test/e2e/users/get-user-e2e-spec.ts
+++ b/test/e2e/users/get-user-e2e-spec.ts
@@ -19,7 +19,7 @@ const GetUserE2ESpec = e2eSuite('GET /users/:userId', (app) => {
   it('should successfully find the user', async () => {
     const userFromDb = await app()
       .get(PrismaService)
-      .user.findUnique({
+      .normalize.user.findUnique({
         where: { login: userToSearch.login },
       });
     const branch = userFromDb.branchSubscriptions.find(

--- a/test/utils/fakedb.ts
+++ b/test/utils/fakedb.ts
@@ -289,7 +289,7 @@ export const createUser = entityFaker(
     );
     const user = await app()
       .get(PrismaService)
-      .withDefaultBehaviour.user.create({
+      .user.create({
         data: {
           hash: params.hash ?? (await app().get(AuthService).getHash(params.password)),
           ...pick(params, 'id', 'login', 'studentId', 'firstName', 'lastName', 'userType'),
@@ -473,7 +473,7 @@ export const createAsso = entityFaker(
   async (app, params) => {
     const asso = await app()
       .get(PrismaService)
-      .asso.create({
+      .normalize.asso.create({
         data: {
           ...omit(params, 'login', 'name', 'descriptionShortTranslationId', 'descriptionTranslationId'),
           login: params.login,
@@ -661,7 +661,7 @@ export const createAnnal = entityFaker(
   async (app, { semester, sender, type, ueof }, { status }) =>
     app()
       .get(PrismaService)
-      .ueAnnal.create({
+      .normalize.ueAnnal.create({
         data: {
           uploadComplete: !(status & CommentStatus.PROCESSING),
           deletedAt: status & CommentStatus.DELETED ? faker.date.recent() : null,
@@ -817,8 +817,7 @@ export const createUe = entityFaker(
           code: params.code,
           createdAt: params.createdAt,
         },
-      })
-      .then(omit('ueofs')),
+      }),
 );
 
 export type CreateUserSubscriptionParameters = Omit<FakeUserUeSubscription, 'ueofCode' | 'semesterId' | 'userId'>;
@@ -879,7 +878,7 @@ export const createUeRating = entityFaker(
   async (app, dependencies, params) => {
     return app()
       .get(PrismaService)
-      .withDefaultBehaviour.ueStarVote.create({
+      .ueStarVote.create({
         data: {
           ...params,
           criterion: {
@@ -914,7 +913,7 @@ export const createComment = entityFaker(
   async (app, dependencies, params) => {
     const rawFakeData = await app()
       .get(PrismaService)
-      .withDefaultBehaviour.ueComment.create({
+      .ueComment.create({
         data: {
           ...omit(params, 'status'),
           validatedAt: params.status & CommentStatus.VALIDATED ? new Date() : undefined,
@@ -971,7 +970,7 @@ export const createCommentReply = entityFaker(
   async (app, dependencies, params) => {
     const rawFakeReply = await app()
       .get(PrismaService)
-      .withDefaultBehaviour.ueCommentReply.create({
+      .ueCommentReply.create({
         data: {
           ...omit(params, 'commentId', 'authorId', 'status'),
           deletedAt: params.status & CommentStatus.DELETED ? new Date() : undefined,


### PR DESCRIPTION
`PrismaService` ralentissait énormément les IDEs (en tout cas mon WebStorm, aucune idée pour VSCode, mais j'imagine que c'était pareil). Cette PR optimise cela.

Breaking change : le comportement par défaut est maintenant d'utiliser le Prisma "normal". On peut utiliser `.normalize` pour normaliser l'entité retournée. On n'utilise plus `$extends` (très lent), `.normalize` retourne simplement un objet avec les entités qui sont normalisables.