### PR TITLE
Fix: CI not passing due to using `pnpm pnpx` commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
           node-version: '20.x'
           cache: 'pnpm'        
       - run: pnpm install --frozen-lockfile
-      - run: pnpm pnpx prisma generate
+      - run: pnpm prisma generate
       - run: pnpm lint
 
   build:
@@ -40,7 +40,7 @@ jobs:
           node-version: '20.x'
           cache: 'pnpm'        
       - run: pnpm install --frozen-lockfile
-      - run: pnpm pnpx prisma generate
+      - run: pnpm prisma generate
       - run: pnpm build
 
   test:


### PR DESCRIPTION
Replace commands `pnpm pnpx ...` with `pnpm ...`